### PR TITLE
removing self from maintainers

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -15,7 +15,6 @@
         "fernandoaleman",
         "nuclearsandwich",
         "mohitsethi",
-        "majormoses",
         "teknofire",
         "rshade",
         "mengesb",


### PR DESCRIPTION


# Description

I am no longer working for a company using chef and I have drifted from the ecosystem over the years. Maybe one day we will cross paths again, either way it was a blast. As we have a healthy group of active maintainers, I gladly give up my access that I no longer need.

## Issues Resolved

- https://github.com/sous-chefs/terraform-github-membership/pull/41#issuecomment-1529105504

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
